### PR TITLE
fixed github urls to 3rd-Eden

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/3rdEden/storage-engine.git"
+    "url": "git+https://github.com/3rd-Eden/storage-engine.git"
   },
   "keywords": [
     "async",
@@ -26,9 +26,9 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/3rdEden/storage-engine/issues"
+    "url": "https://github.com/3rd-Eden/storage-engine/issues"
   },
-  "homepage": "https://github.com/3rdEden/storage-engine#readme",
+  "homepage": "https://github.com/3rd-Eden/storage-engine#readme",
   "dependencies": {
     "eventemitter3": "^3.1.0"
   },


### PR DESCRIPTION
The github link was wrong on npmjs.org, so I thought "why not help fix it"... Extremely small contribution!