### PR TITLE
Encode falsy values, update tests/mocks to reflect string requirement…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Encode falsy values, update tests/mocks to reflect string requirement from AsyncStorage
+
 ### 2.0.0
 
 - Now encodes and decodes data automatically as JSON values.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class StorageEngine extends EventEmitter {
                 if (keyValue.length > 1) {
                   const key = keyValue[0];
                   const value = keyValue[1];
-                  const JSONValue = value ? JSON.stringify(value) : value;
+                  const JSONValue = JSON.stringify(value);
                   return [key, JSONValue];
                 } else {
                   return keyValue;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,26 @@ describe('storage-engine', function () {
       assume(await storage.getItem('foo')).equals('bar');
     });
 
+    it('can store falsey values', async function () {
+      const key = 'falseyValue';
+      await storage.setItem(key, false);
+      assume(await storage.getItem(key)).equals(false);
+      await storage.setItem(key, '');
+      assume(await storage.getItem(key)).equals('');
+      await storage.setItem(key, null);
+      assume(await storage.getItem(key)).equals(null);
+    });
+
+    it('throws on trying to set undefined', async function () {
+      try {
+        await storage.setItem('undefined-value', undefined);
+      } catch (e) {
+        return;
+      }
+
+      throw new Error('It should have thrown');
+    });
+
     it('emits <key> when a new value is get', function (next) {
       storage.once('foo', function (method, value) {
         assume(method).equals('getItem');
@@ -41,33 +61,6 @@ describe('storage-engine', function () {
       });
 
       storage.setItem('pew', 'waddup');
-    });
-
-    it('stores and fetches no value', async function () {
-      await storage.setItem('noValue');
-      assume(await storage.getItem('noValue')).equals(undefined);
-    });
-
-    it('emits <key> when a no value is get', function (next) {
-      storage.once('noValue', function (method, value) {
-        assume(method).equals('getItem');
-        assume(value).equals(undefined);
-
-        next();
-      });
-
-      storage.getItem('noValue');
-    });
-
-    it('emits <key> when a no value is set', function (next) {
-      storage.once('newNoValue', function (method, value) {
-        assume(method).equals('setItem');
-        assume(value).equals(undefined);
-
-        next();
-      });
-
-      storage.setItem('newNoValue', undefined);
     });
 
     it('stores and fetches objects', async function () {
@@ -103,13 +96,33 @@ describe('storage-engine', function () {
       await storage.multiSet([['key1', 'value1'], ['key2', 'value2']]);
 
       assume(await storage.multiGet(['key1', 'key2'])).deep.equals([['key1', 'value1'], ['key2', 'value2']]);
-    })
+    });
 
     it('stores and fetches multiple objects', async function () {
       await storage.multiSet([['key1', { object1: 'object1' }], ['key2', { object2: 'object2' }]]);
 
       assume(await storage.multiGet(['key1', 'key2'])).deep.equals([['key1', { object1: 'object1' }], ['key2', { object2: 'object2' }]]);
-    })
+    });
+
+    it('stores and fetches multiple falsey values', async function () {
+      await storage.multiSet([['key1', ''], ['key2', false], ['key3', null]]);
+
+      assume(await storage.multiGet(['key1', 'key2', 'key3'])).deep.equals([
+        ['key1', ''],
+        ['key2', false],
+        ['key3', null]
+      ]);
+    });
+
+    it('throws on trying to set undefined', async function () {
+      try {
+        await storage.multiSet([['key1', ''], ['key2', undefined], ['key3', null]]);
+      } catch (e) {
+        return;
+      }
+
+      throw new Error('It should have thrown');
+    });
   });
 
   describe('#clear', function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,8 +25,10 @@ describe('storage-engine', function () {
       const key = 'falseyValue';
       await storage.setItem(key, false);
       assume(await storage.getItem(key)).equals(false);
+      
       await storage.setItem(key, '');
       assume(await storage.getItem(key)).equals('');
+
       await storage.setItem(key, null);
       assume(await storage.getItem(key)).equals(null);
     });
@@ -61,6 +63,17 @@ describe('storage-engine', function () {
       });
 
       storage.setItem('pew', 'waddup');
+    });
+
+    it('emits <key> when a no value is get', function (next) {
+      storage.once('noValue', function (method, value) {
+        assume(method).equals('getItem');
+        assume(value).equals(null);
+
+        next();
+      });
+
+      storage.getItem('noValue');
     });
 
     it('stores and fetches objects', async function () {

--- a/test/mock.js
+++ b/test/mock.js
@@ -14,11 +14,13 @@ AsyncStorage.getItem = async (name) => {
 };
 
 AsyncStorage.setItem = async (name, value) => {
+  if (typeof value !== 'string') throw new Error('AsyncStorage requires strings to be stored');
   return AsyncStorage.map.set(name, value);
 };
 
 AsyncStorage.multiSet = async (nameValues) => {
   nameValues.forEach(element => {
+    if (typeof element[1] !== 'string') throw new Error('AsyncStorage requires strings to be stored');
     AsyncStorage.map.set(element[0], element[1]);
   });
   return nameValues;


### PR DESCRIPTION
… from AsyncStorage

Opted for removing the now broken tests around dealing with undefined values since they won't store properly in AsyncStorage and replaced them with a test asserting that it throws on undefined.  We could try to do some tokenization here though if we really want to store an undefined.